### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+---
+version: 2
+updates:
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Adds `.github/dependabot.yml` covering: `docker github-actions` ecosystems on a weekly cadence.

Part of an org-wide audit to close dependency-update automation gaps. No workflow or runtime impact — dependabot will start opening PRs on whatever lives at `/` once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)